### PR TITLE
Update the url to get only five restaurants based on location

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,5 +1,5 @@
 export const getRestaurants = async (lat = 39.7392, lng = -104.9903) => {
-  const response = await fetch(`https://tacoboutit-test.herokuapp.com/api/v1/restaurants/?lat=${lat}?lng=${lng}`);
+  const response = await fetch(`https://tacoboutit-test.herokuapp.com/api/v1/restaurants/retrieve/?lat=${lat}&lng=${lng}`);
   if(!response.ok) {
     throw Error('Failed to fetch restaurants near you');
   }


### PR DESCRIPTION
#### What's this PR do?
* Will update the fetch url used in `getRestaurants` withing `apiCalls`
#### Where should the reviewer start?
* Taking a look at the `apiCalls.js` file
#### How should this be manually tested?
* Running the app on your phone, you'll see locations being displayed based on your location and only five restaurants at a time for now
#### Any background context you want to provide?
* Before it was pulling in locations from farther distances and 5+ restaurants at a time
#### What are the relevant tickets?
#### Screenshots (if appropriate)
![Screen Shot 2020-01-06 at 2 43 59 PM](https://user-images.githubusercontent.com/48504854/71851201-3f630080-3093-11ea-9bb6-89c0f89b7f9f.png)
#### Questions:
