### PR TITLE
New taco add review error

### DIFF
--- a/App.js
+++ b/App.js
@@ -67,8 +67,7 @@ export class App extends Component {
   submitNewTaco = async (type, restaurantId) => {
     const response = await newTaco(type, restaurantId);
     if(!response.error) {
-      const newTaco = { type, restaurant: restaurantId };
-      this.updateLocalTacos(newTaco);
+      this.updateLocalTacos(response);
     }
     return response;
   }

--- a/App.test.js
+++ b/App.test.js
@@ -119,7 +119,7 @@ describe('App', () => {
     const mockUpdateLocalTacos = jest.fn();
     wrapper.instance().updateLocalTacos = mockUpdateLocalTacos;
     const result = await wrapper.instance().submitNewTaco('carne asada', 2);
-    expect(mockUpdateLocalTacos).toHaveBeenCalledWith({"restaurant": 2, "type": "carne asada"});
+    expect(mockUpdateLocalTacos).toHaveBeenCalledWith(mockResponse);
     expect(result).toEqual(mockResponse);
   });
 

--- a/src/components/AddReviewForm/AddReviewForm.js
+++ b/src/components/AddReviewForm/AddReviewForm.js
@@ -64,7 +64,6 @@ export default class AddReviewForm extends Component {
       rating: 1,
       review: '',
       type: this.props.tacos[0].type, 
-      error: ''
     };
     this.setState(initialState);
     this.props.toggleReviewForm();

--- a/src/components/AddReviewForm/AddReviewForm.js
+++ b/src/components/AddReviewForm/AddReviewForm.js
@@ -54,7 +54,20 @@ export default class AddReviewForm extends Component {
         this.setState({error: 'Failed to post review'})
       }
     }
+    this.resetStateCloseModal();
     updateLocalReviews(response)
+  }
+
+  resetStateCloseModal = () => {
+    const initialState = {
+      tacoId: this.props.tacos[0].id,
+      rating: 1,
+      review: '',
+      type: this.props.tacos[0].type, 
+      error: ''
+    };
+    this.setState(initialState);
+    this.props.toggleReviewForm();
   }
 
   render() {

--- a/src/components/AddReviewForm/AddReviewForm.test.js
+++ b/src/components/AddReviewForm/AddReviewForm.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import * as api from '../../apiCalls';
 
 describe('AddReviewForm', () => {
+  const mockToggleReviewForm = jest.fn();
   const mockTacos = [
     {
         "id": 9,
@@ -53,7 +54,11 @@ describe('AddReviewForm', () => {
   let wrapper;
   const mockUpdateLocalReviews = jest.fn();
   beforeEach(() => {
-    wrapper = shallow(<AddReviewForm tacos={mockTacos} updateLocalReviews={mockUpdateLocalReviews}/>);
+    wrapper = shallow(<AddReviewForm 
+      tacos={mockTacos} 
+      updateLocalReviews={mockUpdateLocalReviews}
+      toggleReviewForm={mockToggleReviewForm}
+    />);
   })
   it('should match the snapshot', () => {
     expect(wrapper).toMatchSnapshot();

--- a/src/components/AddTacoButton/AddTacoButton.js
+++ b/src/components/AddTacoButton/AddTacoButton.js
@@ -11,6 +11,7 @@ export default class AddTacoButton extends Component {
     const { submitTaco, id } = this.props;
     const selectedType = this.state.selectedType;
     const result = await submitTaco(selectedType, id);
+    console.log(result);
     this.setState({ showAddTaco: false });
   }
 

--- a/src/components/AddTacoButton/AddTacoButton.js
+++ b/src/components/AddTacoButton/AddTacoButton.js
@@ -11,7 +11,6 @@ export default class AddTacoButton extends Component {
     const { submitTaco, id } = this.props;
     const selectedType = this.state.selectedType;
     const result = await submitTaco(selectedType, id);
-    console.log(result);
     this.setState({ showAddTaco: false });
   }
 


### PR DESCRIPTION
#### What's this PR do?
Adds additional functionality to review form so after a user submits a new review, the form is cleared and collapsed. Fixes error where if a user added a new taco type to a restaurant and immediately tried to review it they would run into an error. Updates tests to reflect changes.
#### Where should the reviewer start?
Switch to branch and make sure all functionality is working on for the app. Try to add a taco type and immediately review it without reloading the page. 
#### How should this be manually tested?
Run through adding taco type, then reviewing it. Run npm test make sure everything is passing.
#### What are the relevant tickets?
#84 #85

